### PR TITLE
Tests assume UnlockExperimentalVMOptions is disabled by default.

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -63,6 +63,7 @@ requires.properties= \
     vm.gc.Z \
     vm.gc.ZGenerational \
     vm.gc.ZSinglegen \
+    vm.unlockExperimentalOptions \
     vm.jvmci \
     vm.jvmci.enabled \
     vm.emulatedClient \

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires ! vm.unlockExperimentalOptions
  * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -26,6 +26,7 @@
  * @bug 8027314
  * @summary Warn if diagnostic or experimental vm option is used and -XX:+UnlockDiagnosticVMOptions or -XX:+UnlockExperimentalVMOptions, respectively, isn't specified. Warn if develop vm option is used with product version of VM.
  * @requires vm.flagless
+ * @requires ! vm.unlockExperimentalOptions
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -104,6 +104,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.flightRecorder", this::vmFlightRecorder);
         map.put("vm.simpleArch", this::vmArch);
         map.put("vm.debug", this::vmDebug);
+        map.put("vm.unlockExperimentalOptions", this::vmUnlockExperimentalOptions);
         map.put("vm.jvmci", this::vmJvmci);
         map.put("vm.jvmci.enabled", this::vmJvmciEnabled);
         map.put("vm.emulatedClient", this::vmEmulatedClient);
@@ -250,6 +251,13 @@ public class VMProps implements Callable<Map<String, String>> {
         } else {
             return errorWithMessage("Can't get 'jdk.debug' property");
         }
+    }
+
+    /**
+     * @return true if VM has experimental options unlocked
+     */
+    protected String vmUnlockExperimentalOptions() {
+        return "" + WB.getBooleanVMFlag("UnlockExperimentalVMOptions");
     }
 
     /**


### PR DESCRIPTION
`-UnlockExperimentalVMOptions` isn't necessarily the default: a distro may enable it in order to default-enable other features like JVMCI/Graal.

On top of the expected discussion as to whether this is an appropriate vmprop to add, I'm also not entirely satisfied by adding a `@require` that only applies to a subset of the checks in a test class.  In `VMOptionWarning`, the experimental flag only applies to the first of the three scenarios it checks.  But I suspect this is a general problem with `@require`, and I'd be happy to hear suggestions on how to avoid disabling too much.
